### PR TITLE
[Feat] 기사 리스트 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,11 @@ repositories {
 }
 
 dependencies {
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/newlearn/newlearn/article/controller/ArticleController.java
+++ b/src/main/java/com/newlearn/newlearn/article/controller/ArticleController.java
@@ -1,0 +1,40 @@
+package com.newlearn.newlearn.article.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.newlearn.newlearn.article.dto.MainArticleResponseDto;
+import com.newlearn.newlearn.article.service.ArticleService;
+import com.newlearn.newlearn.common.exception.SuccessCode;
+import com.newlearn.newlearn.common.response.BaseApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/v1/articles")
+@RequiredArgsConstructor
+public class ArticleController {
+
+	private final ArticleService articleService;
+
+	@Operation(summary = "기사 리스트 조회 API", description = "기사 리스트 조회 API입니다. 8시간 주기로 크롤링 해 온 네이버 뉴스를 Redis에 담고 만료시간을 당일 자정으로 설정했습니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "기사 리스트 조회 성공")
+	})
+	@GetMapping("/{categoryId}")
+	public ResponseEntity<BaseApiResponse<MainArticleResponseDto>> getAllArticles(
+		@PathVariable Long categoryId,
+		@RequestParam int page,
+		@RequestParam(required = false, defaultValue = "10") int size) {
+		MainArticleResponseDto response = articleService.getArticles(categoryId, page, size);
+
+		return BaseApiResponse.success(SuccessCode.SUCCESS_GET_ARTICLES, response);
+	}
+}

--- a/src/main/java/com/newlearn/newlearn/article/dto/MainArticleResponseDto.java
+++ b/src/main/java/com/newlearn/newlearn/article/dto/MainArticleResponseDto.java
@@ -1,0 +1,27 @@
+package com.newlearn.newlearn.article.dto;
+
+import java.util.List;
+
+import com.newlearn.newlearn.article.entity.RedisArticle;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MainArticleResponseDto {
+	private List<RedisArticle> articles;
+	private boolean hasNext;
+
+	@Builder
+	public MainArticleResponseDto(List<RedisArticle> articles, boolean hasNext) {
+		this.articles = articles;
+		this.hasNext = hasNext;
+	}
+
+	public static MainArticleResponseDto toDto(List<RedisArticle> redisArticles, boolean hasNext) {
+		return MainArticleResponseDto.builder()
+			.articles(redisArticles)
+			.hasNext(hasNext)
+			.build();
+	}
+}

--- a/src/main/java/com/newlearn/newlearn/article/entity/Article.java
+++ b/src/main/java/com/newlearn/newlearn/article/entity/Article.java
@@ -1,4 +1,4 @@
-package com.newlearn.newlearn.news.entity;
+package com.newlearn.newlearn.article.entity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -7,9 +7,9 @@ import org.hibernate.annotations.ColumnDefault;
 
 import com.newlearn.newlearn.category.entity.Category;
 import com.newlearn.newlearn.common.BaseTimeEntity;
-import com.newlearn.newlearn.news_history.entity.NewsHistory;
-import com.newlearn.newlearn.news_image.entity.NewsImage;
-import com.newlearn.newlearn.scraped_news.entity.ScrapedNews;
+import com.newlearn.newlearn.article_history.entity.ArticleHistory;
+import com.newlearn.newlearn.article_image.entity.ArticleImage;
+import com.newlearn.newlearn.scraped_article.entity.ScrapedArticle;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -27,10 +27,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class News extends BaseTimeEntity {
+public class Article extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "news_id")
+	@Column(name = "article_id")
 	private Long id;
 	@Column(length = 200)
 	private String title;
@@ -42,12 +42,12 @@ public class News extends BaseTimeEntity {
 	@JoinColumn(name = "category_id")
 	private Category category;
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "news_agency_id")
-	private NewsAgency newsAgency;
-	@OneToMany(mappedBy = "news")
-	private List<NewsImage> newsImages = new ArrayList<>();
-	@OneToMany(mappedBy = "news")
-	private List<ScrapedNews> scrapedNews = new ArrayList<>();
-	@OneToMany(mappedBy = "news")
-	private List<NewsHistory> newsHistories = new ArrayList<>();
+	@JoinColumn(name = "article_agency_id")
+	private ArticleAgency articleAgency;
+	@OneToMany(mappedBy = "article")
+	private List<ArticleImage> articleImages = new ArrayList<>();
+	@OneToMany(mappedBy = "article")
+	private List<ScrapedArticle> scrapedArticles = new ArrayList<>();
+	@OneToMany(mappedBy = "article")
+	private List<ArticleHistory> articleHistories = new ArrayList<>();
 }

--- a/src/main/java/com/newlearn/newlearn/article/entity/ArticleAgency.java
+++ b/src/main/java/com/newlearn/newlearn/article/entity/ArticleAgency.java
@@ -1,4 +1,4 @@
-package com.newlearn.newlearn.news.entity;
+package com.newlearn.newlearn.article.entity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,13 +16,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class NewsAgency {
+public class ArticleAgency {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "news_agency_id")
+	@Column(name = "article_agency_id")
 	private Long id;
 	@Column(length = 30)
 	private String name;
-	@OneToMany(mappedBy = "newsAgency")
-	private List<News> news = new ArrayList<>();
+	@OneToMany(mappedBy = "articleAgency")
+	private List<Article> news = new ArrayList<>();
 }

--- a/src/main/java/com/newlearn/newlearn/article/entity/RedisArticle.java
+++ b/src/main/java/com/newlearn/newlearn/article/entity/RedisArticle.java
@@ -1,0 +1,18 @@
+package com.newlearn.newlearn.article.entity;
+
+import java.io.Serializable;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RedisArticle implements Serializable {
+	private Long articleId;
+	private String title;
+	private String source;
+	private String publishedDate;
+	private String thumbnail;
+	private String content;
+}

--- a/src/main/java/com/newlearn/newlearn/article/entity/RedisArticle.java
+++ b/src/main/java/com/newlearn/newlearn/article/entity/RedisArticle.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class RedisArticle implements Serializable {
-	private Long articleId;
+	private Long redisArticleId;
 	private String title;
 	private String source;
 	private String publishedDate;

--- a/src/main/java/com/newlearn/newlearn/article/exception/ArticleException.java
+++ b/src/main/java/com/newlearn/newlearn/article/exception/ArticleException.java
@@ -1,0 +1,10 @@
+package com.newlearn.newlearn.article.exception;
+
+import com.newlearn.newlearn.common.exception.ApiException;
+import com.newlearn.newlearn.common.exception.BaseCode;
+
+public class ArticleException extends ApiException {
+	public ArticleException(BaseCode code) {
+		super(code);
+	}
+}

--- a/src/main/java/com/newlearn/newlearn/article/service/ArticleService.java
+++ b/src/main/java/com/newlearn/newlearn/article/service/ArticleService.java
@@ -1,0 +1,67 @@
+package com.newlearn.newlearn.article.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.newlearn.newlearn.article.dto.MainArticleResponseDto;
+import com.newlearn.newlearn.article.entity.RedisArticle;
+import com.newlearn.newlearn.article.exception.ArticleException;
+import com.newlearn.newlearn.common.exception.ErrorCode;
+
+import java.util.List;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ArticleService {
+	private static final String REDIS_KEY = "articles:category:";
+	private static final int NEXT_PAGE_OFFSET = 1;
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final ObjectMapper objectMapper;
+
+	public MainArticleResponseDto getArticles(Long categoryId, int page, int size) {
+		String redisKey = generateRedisKey(categoryId);
+
+		String jsonString = redisTemplate.opsForValue().get(redisKey);
+		if (jsonString == null || jsonString.isEmpty()) {
+			throw new ArticleException(ErrorCode.NOT_EXIST_ARTICLE_BY_CATEGORY);
+		}
+		List<RedisArticle> articles = deserializeArticles(jsonString);
+
+		List<RedisArticle> pagedArticles = paginateArticles(articles, page, size);
+		boolean hasNext = (page + NEXT_PAGE_OFFSET) * size < articles.size();
+
+		return MainArticleResponseDto.toDto(pagedArticles, hasNext);
+	}
+
+	private String generateRedisKey(Long categoryId) {
+		return REDIS_KEY + categoryId;
+	}
+
+	// JSON 문자열을 리스트로 변환
+	private List<RedisArticle> deserializeArticles(String jsonString) {
+		try {
+			return objectMapper.readValue(jsonString,
+				objectMapper.getTypeFactory().constructCollectionType(List.class, RedisArticle.class));
+		} catch (Exception e) {
+			throw new ArticleException(ErrorCode.FAILED_TO_PARSE_JSON_TO_LIST);
+		}
+	}
+
+	// 페이지네이션 처리
+	private List<RedisArticle> paginateArticles(List<RedisArticle> articles, int page, int size) {
+		int start = page * size;
+		if (start >= articles.size()) {
+			return List.of();
+		}
+		int end = Math.min(start + size, articles.size());
+
+		return articles.subList(start, end);
+	}
+}
+

--- a/src/main/java/com/newlearn/newlearn/article_history/entity/ArticleHistory.java
+++ b/src/main/java/com/newlearn/newlearn/article_history/entity/ArticleHistory.java
@@ -1,6 +1,10 @@
-package com.newlearn.newlearn.scraped_news.entity;
+package com.newlearn.newlearn.article_history.entity;
 
-import com.newlearn.newlearn.news.entity.News;
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+
+import com.newlearn.newlearn.article.entity.Article;
 import com.newlearn.newlearn.user.entity.User;
 
 import jakarta.persistence.Column;
@@ -18,15 +22,17 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ScrapedNews {
+public class ArticleHistory {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "scraped_agency_id")
+	@Column(name = "article_history_id")
 	private Long id;
+	@CreatedDate
+	private LocalDateTime createdAt;
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "news_id")
-	private News news;
+	@JoinColumn(name = "article_id")
+	private Article article;
 }

--- a/src/main/java/com/newlearn/newlearn/article_image/entity/ArticleImage.java
+++ b/src/main/java/com/newlearn/newlearn/article_image/entity/ArticleImage.java
@@ -1,7 +1,7 @@
-package com.newlearn.newlearn.news_image.entity;
+package com.newlearn.newlearn.article_image.entity;
 
 import com.newlearn.newlearn.image.entity.Image;
-import com.newlearn.newlearn.news.entity.News;
+import com.newlearn.newlearn.article.entity.Article;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,15 +18,15 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class NewsImage {
+public class ArticleImage {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "news_image_id")
+	@Column(name = "article_image_id")
 	private Long id;
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "image_id")
 	private Image image;
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "news_id")
-	private News news;
+	@JoinColumn(name = "article_id")
+	private Article article;
 }

--- a/src/main/java/com/newlearn/newlearn/common/config/JacksonConfig.java
+++ b/src/main/java/com/newlearn/newlearn/common/config/JacksonConfig.java
@@ -1,0 +1,31 @@
+package com.newlearn.newlearn.common.config;
+
+import java.io.IOException;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+@Configuration
+public class JacksonConfig {
+	@Bean
+	public ObjectMapper objectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new SimpleModule().addSerializer(String.class, new JsonSerializer<>() {
+			@Override
+			public void serialize(String value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+				if (value != null) {
+					gen.writeString(value.replace("\n", "<br/>")); // 또는 "  "
+				} else {
+					gen.writeNull();
+				}
+			}
+		}));
+		return objectMapper;
+	}
+}

--- a/src/main/java/com/newlearn/newlearn/common/config/RedisConfig.java
+++ b/src/main/java/com/newlearn/newlearn/common/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package com.newlearn.newlearn.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+
+@Configuration
+public class RedisConfig {
+	@Bean
+	public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, String> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new StringRedisSerializer());
+		return template;
+	}
+}

--- a/src/main/java/com/newlearn/newlearn/common/exception/ErrorCode.java
+++ b/src/main/java/com/newlearn/newlearn/common/exception/ErrorCode.java
@@ -9,7 +9,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode implements BaseCode {
 	// ---- [User] ---- //
-	NOT_EXIST_PLATFORM(HttpStatus.BAD_REQUEST, "존재하지 않는 플랫폼입니다" );
+	NOT_EXIST_PLATFORM(HttpStatus.BAD_REQUEST, "존재하지 않는 플랫폼입니다" ),
+
+	// ---- [Article] ---- //
+	NOT_EXIST_ARTICLE_BY_CATEGORY(HttpStatus.INTERNAL_SERVER_ERROR, "카테고리에 해당하는 뉴스가 존재하지 않습니다."),
+	FAILED_TO_PARSE_JSON_TO_LIST(HttpStatus.BAD_REQUEST, "문자열을 리스트 형식으로 변환할 수 없습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/newlearn/newlearn/common/exception/SuccessCode.java
+++ b/src/main/java/com/newlearn/newlearn/common/exception/SuccessCode.java
@@ -9,7 +9,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SuccessCode implements BaseCode {
 	// ----- [Test] ------ //
-	TEST_SUCCESS(HttpStatus.OK, "테스트 성공");
+	TEST_SUCCESS(HttpStatus.OK, "테스트 성공"),
+
+	// ----- [Articles] ------ //
+	SUCCESS_GET_ARTICLES(HttpStatus.OK, "기사 리스트 조회 성공");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/newlearn/newlearn/image/entity/Image.java
+++ b/src/main/java/com/newlearn/newlearn/image/entity/Image.java
@@ -3,7 +3,7 @@ package com.newlearn.newlearn.image.entity;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.newlearn.newlearn.news_image.entity.NewsImage;
+import com.newlearn.newlearn.article_image.entity.ArticleImage;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -27,5 +27,5 @@ public class Image {
 	private String url;
 	private boolean isThumbnail;
 	@OneToMany(mappedBy = "image")
-	private List<NewsImage> newsImages = new ArrayList<>();
+	private List<ArticleImage> articleImages = new ArrayList<>();
 }

--- a/src/main/java/com/newlearn/newlearn/scraped_article/entity/ScrapedArticle.java
+++ b/src/main/java/com/newlearn/newlearn/scraped_article/entity/ScrapedArticle.java
@@ -1,10 +1,6 @@
-package com.newlearn.newlearn.news_history.entity;
+package com.newlearn.newlearn.scraped_article.entity;
 
-import java.time.LocalDateTime;
-
-import org.springframework.data.annotation.CreatedDate;
-
-import com.newlearn.newlearn.news.entity.News;
+import com.newlearn.newlearn.article.entity.Article;
 import com.newlearn.newlearn.user.entity.User;
 
 import jakarta.persistence.Column;
@@ -22,17 +18,15 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class NewsHistory {
+public class ScrapedArticle {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "news_history_id")
+	@Column(name = "scraped_agency_id")
 	private Long id;
-	@CreatedDate
-	private LocalDateTime createdAt;
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "news_id")
-	private News news;
+	@JoinColumn(name = "article_id")
+	private Article article;
 }

--- a/src/main/java/com/newlearn/newlearn/user/entity/User.java
+++ b/src/main/java/com/newlearn/newlearn/user/entity/User.java
@@ -8,8 +8,8 @@ import org.hibernate.annotations.DynamicInsert;
 
 import com.newlearn.newlearn.common.BaseTimeEntity;
 import com.newlearn.newlearn.like_category.entity.LikeCategory;
-import com.newlearn.newlearn.news_history.entity.NewsHistory;
-import com.newlearn.newlearn.scraped_news.entity.ScrapedNews;
+import com.newlearn.newlearn.article_history.entity.ArticleHistory;
+import com.newlearn.newlearn.scraped_article.entity.ScrapedArticle;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -44,7 +44,7 @@ public class User extends BaseTimeEntity {
 	@OneToMany(mappedBy = "user")
 	private List<LikeCategory> likeCategories = new ArrayList<>();
 	@OneToMany(mappedBy = "user")
-	private List<ScrapedNews> scrapedNews = new ArrayList<>();
+	private List<ScrapedArticle> scrapedArticles = new ArrayList<>();
 	@OneToMany(mappedBy = "user")
-	private List<NewsHistory> newsHistories = new ArrayList<>();
+	private List<ArticleHistory> articleHistories = new ArrayList<>();
 }


### PR DESCRIPTION
## What is this PR? 👓
- 페이징 처리가 가능하도록 만들었습니다. `page`는 `0`부터 시작하며 `size`는 default 값으로 `10`을 주었습니다.
- 응답에 `hasNext` 값을 boolean으로 주어 다음 페이지 유무를 표현하도록 만들었습니다. 무한 스크롤 형식으로 구현할 경우 이 값을 확인하면 좋을 것 같습니다.
- content 값에 줄바꿈 문자 `\n` 이 들어가는 문제가 발생하여 JacksonConfig에서 ObjectMapper를 커스텀하여 `\n`을 `<br/>`로 변경하도록 만들었습니다.

## Key changes 🔑
이전에 `news`로 명명한 것들을 모두 articles로 변경하였습니다.

## To reviewers 👋
- 응답에 `content `값이 포함되어 있습니다. 상세 조회의 경우 리스트에서 값을 꺼내 바로 조회하면 될 것 같고 상세 조회 시 열람한 기사 생성 API를 호출해주시면 좋을 것 같습니다.
- 요청, 응답 형식에 관한 내용은 노션의 `api 명세서` 문서를 업데이트 했습니다.
- 노션의 secretes 에서 `application.yml` 파일도 업데이트 되었습니다.
- 스프링 프로젝트 실행 후 `http://localhost:8080/swagger-ui/index.html` 경로에서 API 테스트 가능합니다. 배포 후 localhost가 아닌 ip만 서버 ip로 변경하면 접속 가능하도록 만들 예정입니다.
